### PR TITLE
Create no auth security option for development purposes

### DIFF
--- a/src/main/kotlin/sk/streetofcode/webapi/configuration/SecurityConfiguration.kt
+++ b/src/main/kotlin/sk/streetofcode/webapi/configuration/SecurityConfiguration.kt
@@ -13,7 +13,7 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtGra
 
 @Configuration
 @EnableGlobalMethodSecurity(prePostEnabled = true)
-@Profile("!test")
+@Profile("!test & !noauth")
 class SecurityConfiguration : WebSecurityConfigurerAdapter() {
     companion object {
         const val AUTHORITY_PREFIX = "ROLE_"

--- a/src/main/kotlin/sk/streetofcode/webapi/configuration/SecurityNoAuthConfiguration.kt
+++ b/src/main/kotlin/sk/streetofcode/webapi/configuration/SecurityNoAuthConfiguration.kt
@@ -1,0 +1,17 @@
+package sk.streetofcode.webapi.configuration
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
+
+@Configuration
+@Profile("noauth")
+class SecurityNoAuthConfiguration : WebSecurityConfigurerAdapter() {
+
+    override fun configure(http: HttpSecurity) {
+        http.csrf().disable().authorizeRequests().antMatchers("/**").permitAll()
+        // To enable H2
+        http.headers().frameOptions().disable()
+    }
+}


### PR DESCRIPTION
Create new run configuration with `noauth` profile set. Profile is set in `Environment variables` section

![Screenshot 2023-01-14 192405](https://user-images.githubusercontent.com/10036698/212489761-5fc2e092-ca6b-4920-bb28-7536de2b28c6.png)
